### PR TITLE
feat: Segregate Auth server from WAS

### DIFF
--- a/auth-server/build.gradle
+++ b/auth-server/build.gradle
@@ -1,6 +1,15 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.0'
+    implementation 'org.springframework.cloud:spring-cloud-starter-config:3.1.4'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    runtimeOnly 'com.h2database:h2:1.4.200'
+    runtimeOnly 'mysql:mysql-connector-java'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/auth-server/build.gradle
+++ b/auth-server/build.gradle
@@ -1,0 +1,16 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-devtools
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+configurations {
+    runtimeClasspath{
+        extendsFrom developmentOnly
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/AuthServer.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/AuthServer.java
@@ -1,0 +1,11 @@
+package com.huyeon.authserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AuthServer {
+    public static void main(String[] args) {
+        SpringApplication.run(AuthServer.class, args);
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/auth/controller/AuthController.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/auth/controller/AuthController.java
@@ -1,0 +1,44 @@
+package com.huyeon.authserver.auth.controller;
+
+import com.huyeon.authserver.auth.dto.UserSignInReq;
+import com.huyeon.authserver.auth.dto.UserSignUpReq;
+import com.huyeon.authserver.auth.service.AuthService;
+import com.huyeon.authserver.jwt.JwtFilter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+
+@Slf4j
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void signUp(@RequestBody UserSignUpReq request) {
+        authService.signUp(request);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> logIn(@RequestBody UserSignInReq request) {
+        String jwt = "Bearer " + authService.logIn(request);
+
+        return new ResponseEntity<>(jwt, HttpStatus.OK);
+    }
+
+    @PostMapping("/check")
+    public ResponseEntity<?> checkDuplicateEmail(@RequestBody String email) {
+        boolean isDuplicate = authService.isDuplicateEmail(email);
+        return new ResponseEntity<>(isDuplicate, HttpStatus.OK);
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/auth/dto/UserSignInReq.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/auth/dto/UserSignInReq.java
@@ -1,0 +1,14 @@
+package com.huyeon.authserver.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSignInReq {
+    private String email;
+    private String password;
+    private boolean rememberMe;
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/auth/dto/UserSignUpReq.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/auth/dto/UserSignUpReq.java
@@ -1,0 +1,20 @@
+package com.huyeon.authserver.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSignUpReq {
+    private String name;
+
+    private String email;
+
+    private String password;
+
+    private LocalDate birthday;
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/auth/entity/Authority.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/auth/entity/Authority.java
@@ -1,0 +1,43 @@
+package com.huyeon.authserver.auth.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.util.Objects;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class Authority implements GrantedAuthority {
+    public static final String ROLE_USER = "ROLE_USER";
+    public static final String ROLE_SUBSCRIBER = "ROLE_SUBSCRIBER";
+    public static final String ROLE_ADMIN = "ROLE_ADMIN";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String authority;
+
+    public Authority(String authority) {
+        this.authority = authority;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Authority)) return false;
+        Authority targetAuth = (Authority) o;
+        return Objects.equals(authority, targetAuth.authority);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authority);
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/auth/entity/User.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/auth/entity/User.java
@@ -1,0 +1,61 @@
+package com.huyeon.authserver.auth.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.huyeon.authserver.auth.dto.UserSignUpReq;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "user")
+public class User {
+    @Id
+    private String email;
+
+    private String name;
+
+    private String password;
+
+    private LocalDate birthday;
+
+    private boolean enabled;
+
+    @JsonIgnore
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(foreignKey = @ForeignKey(name = "user_email"))
+    private Set<Authority> authorities = new HashSet<>();
+
+    @Column(updatable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd kk:mm:ss")
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd kk:mm:ss")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public User(UserSignUpReq request) {
+        name = request.getName();
+        email = request.getEmail();
+        password = request.getPassword();
+        enabled = true;
+        authorities.add(new Authority(Authority.ROLE_USER));
+        if(request.getBirthday() != null) birthday = request.getBirthday();
+    }
+
+    public void encryptPassword(PasswordEncoder passwordEncoder) {
+        password = passwordEncoder.encode(password);
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/auth/repository/AuthRepository.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/auth/repository/AuthRepository.java
@@ -1,0 +1,19 @@
+package com.huyeon.authserver.auth.repository;
+
+import com.huyeon.authserver.auth.entity.User;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AuthRepository extends JpaRepository<User, String> {
+    Optional<User> findByEmail(String email);
+
+    //EAGER 조회로 권한 정보를 같이 가져옴
+    @EntityGraph(attributePaths = "authorities")
+    Optional<User> findWithAuthoritiesByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/auth/service/AuthService.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/auth/service/AuthService.java
@@ -1,0 +1,50 @@
+package com.huyeon.authserver.auth.service;
+
+import com.huyeon.authserver.auth.dto.UserSignInReq;
+import com.huyeon.authserver.auth.dto.UserSignUpReq;
+import com.huyeon.authserver.auth.entity.User;
+import com.huyeon.authserver.auth.repository.AuthRepository;
+import com.huyeon.authserver.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final AuthRepository authRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    @Transactional
+    public void signUp(UserSignUpReq request) {
+        User user = new User(request);
+        user.encryptPassword(passwordEncoder);
+        authRepository.save(user);
+    }
+
+    //로그인
+    public String logIn(UserSignInReq request) {
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
+
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return tokenProvider.createToken(authentication);
+    }
+
+    //이메일 중복체크
+    public boolean isDuplicateEmail(String email) {
+        return authRepository.existsByEmail(email);
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/auth/service/UserDetailsServiceImpl.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/auth/service/UserDetailsServiceImpl.java
@@ -1,0 +1,51 @@
+package com.huyeon.authserver.auth.service;
+
+import com.huyeon.authserver.auth.entity.User;
+import com.huyeon.authserver.auth.repository.AuthRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * AuthenticationManger를 직접 정의하지 않고, AuthenticationManagerFactoryBean을 통해 주입받았기 때문에
+ * 이 AuthenticationManger는 DaoAuthenticationProvider를 Default AuthenticationProvider로 설정한다.
+ * <p>
+ * DaoAuthenticationProvider는 반드시 1개의 UserDetailsService를 발견할 수 있어야한다.
+ * 만약 없다면, InmemoryUserDetailsManager에 사용자가 등록되어 제공된다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final AuthRepository authRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return authRepository.findWithAuthoritiesByEmail(email)
+                .map(user -> createUser(email, user))
+                .orElseThrow(() -> new UsernameNotFoundException("등록되지 않은 사용자입니다."));
+    }
+
+    private org.springframework.security.core.userdetails.User createUser(String email, User user) {
+        if (!user.isEnabled()) {
+            throw new RuntimeException(email + " -> 활성화되어 있지 않습니다.");
+        }
+
+        List<GrantedAuthority> grantedAuthorities = user.getAuthorities().stream()
+                .map(authority -> new SimpleGrantedAuthority(authority.getAuthority()))
+                .collect(Collectors.toList());
+
+        return new org.springframework.security.core.userdetails.User(user.getEmail(),
+                user.getPassword(),
+                grantedAuthorities);
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/config/CorsConfig.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.huyeon.authserver.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        source.registerCorsConfiguration("/api/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/config/JwtSecurityConfig.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/config/JwtSecurityConfig.java
@@ -1,0 +1,23 @@
+package com.huyeon.authserver.config;
+
+import com.huyeon.authserver.jwt.JwtFilter;
+import com.huyeon.authserver.jwt.TokenProvider;
+import lombok.AllArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@AllArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private TokenProvider tokenProvider;
+
+    @Override
+    public void configure(HttpSecurity http) {
+        http.addFilterBefore(
+                new JwtFilter(tokenProvider),
+                UsernamePasswordAuthenticationFilter.class
+        );
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/config/SecurityConfig.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/config/SecurityConfig.java
@@ -1,0 +1,79 @@
+package com.huyeon.authserver.config;
+
+import com.huyeon.authserver.jwt.JwtAccessDeniedHandler;
+import com.huyeon.authserver.jwt.JwtAuthenticationEntryPoint;
+import com.huyeon.authserver.jwt.TokenProvider;
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.CorsFilter;
+
+@AllArgsConstructor
+@EnableWebSecurity(debug = true)
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class SecurityConfig {
+    private final TokenProvider tokenProvider;
+    private final CorsFilter corsFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                //JWT 사용
+                .csrf().disable()
+
+                .httpBasic().disable()
+
+                .logout()
+                .logoutUrl("/logout")
+                .logoutSuccessUrl("/")
+                .deleteCookies("remember-me", "JSESSIONID")
+
+                .and()
+                .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
+
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+                //JWT Exception Handling
+                .and()
+                .exceptionHandling()
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler)
+                .accessDeniedPage("/access-denied")
+
+                //Authorize Request
+                .and()
+                .authorizeHttpRequests()
+                .antMatchers("/", "/**").permitAll()
+                .anyRequest().authenticated()
+
+                //JWT Config
+                .and()
+                .apply(new JwtSecurityConfig(tokenProvider))
+
+                .and()
+                .rememberMe();
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/jwt/JwtAccessDeniedHandler.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.huyeon.authserver.jwt;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        //필요한 권한이 없이 접근하려 할때 403
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/jwt/JwtAuthenticationEntryPoint.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package com.huyeon.authserver.jwt;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        // 유효한 자격증명을 제공하지 않고 접근하려 할때 401
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/jwt/JwtFilter.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/jwt/JwtFilter.java
@@ -1,0 +1,59 @@
+package com.huyeon.authserver.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@Slf4j
+@AllArgsConstructor
+public class JwtFilter extends GenericFilterBean {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private TokenProvider tokenProvider;
+
+    @Override
+    public void doFilter(
+            ServletRequest servletRequest,
+            ServletResponse servletResponse,
+            FilterChain filterChain
+    ) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+        String requestURI = httpServletRequest.getRequestURI();
+
+        String jwt = resolveToken(httpServletRequest);
+
+        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+            Authentication authentication = tokenProvider.getAuthentication(jwt);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            log.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
+        } else {
+            log.debug("유효한 JWT 토큰이 없습니다, uri: {}", requestURI);
+        }
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        //[Bearer ]는 Token 앞에 붙여야 하는 규격임
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+
+        return null;
+    }
+}

--- a/auth-server/src/main/java/com/huyeon/authserver/jwt/TokenProvider.java
+++ b/auth-server/src/main/java/com/huyeon/authserver/jwt/TokenProvider.java
@@ -1,0 +1,108 @@
+package com.huyeon.authserver.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class TokenProvider implements InitializingBean {
+    private static final String AUTHORITIES_KEY = "auth";
+    private final String secret;
+    private final long tokenValidityInMilliseconds;
+    private Key key;
+
+    /**
+     * Bean이 생성되고 생성자에서 yaml 파일에 설정해 놓은 값을 주입 받은 후
+     * secret값을 Base64로 Decode해 key변수에 할당 (afterPropertiesSet)
+     */
+    public TokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.token-validity-in-seconds}") long tokenValidityInMilliseconds) {
+        this.secret = secret;
+        this.tokenValidityInMilliseconds = tokenValidityInMilliseconds * 1000;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = new Date().getTime();
+        Date validity = new Date(now + tokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .setExpiration(validity)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = getClaim(token);
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        //Spring Security Core의 User
+        User principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    private Claims getClaim(String token) {
+        return parseClaims(token).getBody();
+    }
+
+    private Jws<Claims> parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    public String getSubject(String token) {
+        Claims claims = getClaim(token);
+        return claims.getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+}

--- a/auth-server/src/main/resources/application.yml
+++ b/auth-server/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+server:
+  port: 8002
+
+spring:
+  config:
+    import: optional:configserver:http://localhost:8888
+  application:
+    name: auth
+  profiles:
+    active: dev
+
+encrypt:
+  key: ${ENCRYPT_KEY}

--- a/auth-server/src/test/java/com/huyeon/authserver/auth/repository/AuthRepoTest.java
+++ b/auth-server/src/test/java/com/huyeon/authserver/auth/repository/AuthRepoTest.java
@@ -1,0 +1,32 @@
+package com.huyeon.authserver.auth.repository;
+
+import com.huyeon.authserver.auth.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+public class AuthRepoTest {
+    @Autowired
+    AuthRepository authRepository;
+
+    @Test
+    @DisplayName("DB에서 사용자 정보 조회")
+    void findUser(){
+        //given
+        String email = "test@test.com";
+
+        //when
+        Optional<User> user = authRepository.findByEmail(email);
+
+        //then
+        assertTrue(user.isPresent());
+        assertEquals(email, user.get().getEmail());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'skeleton'
 include 'server'
 include 'config-server'
+include 'auth-server'


### PR DESCRIPTION
기존 WAS에서 담당하던 인증 기능을 분리하여 인증서버 구성
회원가입, 로그인 기능은 이 인증서버가 담당하며 이곳에서 JWT 토큰 발급
발급된 토큰은 추후 추가될 게이트웨이에서 검사 후 해당 uri로 라우팅하거나,
인증서버로 보내 인증받게 함.